### PR TITLE
fix: run tests in nested test directories

### DIFF
--- a/.github/workflows/scripts/run_affected_tests
+++ b/.github/workflows/scripts/run_affected_tests
@@ -151,7 +151,7 @@ main() {
 	done
 
 	# Find all test files in package directories:
-	files=$(find ${directories} -maxdepth 2 -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
+	files=$(find ${directories} -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
 
 	# Exclude files residing in test fixtures directories:
 	files=$(echo "${files}" | grep -v '/fixtures/') || true


### PR DESCRIPTION
Fixes the issue where tests in nested directories were not being run by the test workflow.

This PR addresses the issue by removing the `-maxdepth 2` constraint from the find command in the `run_affected_tests` script, allowing it to recursively search through all directories under the package directories, finding all test files regardless of how deeply they are nested.

Resolves stdlib-js/stdlib#2096