### PR TITLE
Fix: run tests in nested test directories

### DIFF
--- a/.github/workflows/scripts/run_affected_tests
+++ b/.github/workflows/scripts/run_affected_tests
@@ -151,7 +151,7 @@ main() {
 	done
 
 	# Find all test files in package directories:
-	files=$(find ${directories} -maxdepth 2 -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
+	files=$(find ${directories} -path '**/test*/test*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
 
 	# Exclude files residing in test fixtures directories:
 	files=$(echo "${files}" | grep -v '/fixtures/') || true

--- a/final_verification.sh
+++ b/final_verification.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Final test verification script
+
+# Define directories to search
+directories="lib/node_modules/@stdlib/mock-package"
+
+# Find test files with original pattern
+echo "Original pattern (with maxdepth 2 and -wholename):"
+original_files=$(find ${directories} -maxdepth 2 -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u)
+echo "$original_files"
+echo ""
+
+# Find test files with our new pattern
+echo "New pattern (with -path '**/test*/test*.js'):"
+new_files=$(find ${directories} -path '**/test*/test*.js' | grep -v '/fixtures/' | sort -u)
+echo "$new_files"

--- a/lib/node_modules/@stdlib/mock-package/test/fixtures/test.js
+++ b/lib/node_modules/@stdlib/mock-package/test/fixtures/test.js
@@ -1,0 +1,1 @@
+// Fixture test file that should be excluded

--- a/lib/node_modules/@stdlib/mock-package/test/nested/deeper/test.js
+++ b/lib/node_modules/@stdlib/mock-package/test/nested/deeper/test.js
@@ -1,0 +1,1 @@
+// Deeper nested test file

--- a/lib/node_modules/@stdlib/mock-package/test/nested/test.js
+++ b/lib/node_modules/@stdlib/mock-package/test/nested/test.js
@@ -1,0 +1,1 @@
+// Nested test file

--- a/lib/node_modules/@stdlib/mock-package/test/test.js
+++ b/lib/node_modules/@stdlib/mock-package/test/test.js
@@ -1,0 +1,1 @@
+// Top level test file

--- a/test_verification.sh
+++ b/test_verification.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Test script to verify fix for nested test directories using the exact patterns from the CI script
+
+# Define directories to search
+directories="lib/node_modules/@stdlib/mock-package"
+
+# Find test files with original pattern (with maxdepth 2)
+echo "Original pattern (with maxdepth 2):"
+original_files=$(find ${directories} -maxdepth 2 -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u)
+echo "$original_files"
+echo ""
+
+# Find test files with fixed pattern (without maxdepth limit)
+echo "Fixed pattern (without maxdepth limit):"
+fixed_files=$(find ${directories} -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u)
+echo "$fixed_files"


### PR DESCRIPTION
## Issue 
The CI workflow was not running tests located in nested directories under the test folder. Tests in directories like `test/nested/` were being skipped during CI runs, leading to potential undetected failures.

## Solution
This PR fixes the issue by updating the pattern used to find test files in the `run_affected_tests` script:

1. Changed from `find -wholename` to `find -path`
2. Updated the path pattern from `**/test/test*.js` to `**/test*/test*.js`

This ensures that tests in nested directories like `test/nested/test.js` will be properly discovered and executed during CI runs.

## Testing Evidence
I created a mock package structure with test files in various nested directories to verify that the changes correctly find all test files:

```
lib/node_modules/@stdlib/mock-package/
├── test/
│   ├── test.js                 (top-level test file)
│   ├── nested/
│   │   ├── test.js             (nested test file)
│   │   └── deeper/
│   │       └── test.js         (deeper nested test file)
│   └── fixtures/
│       └── test.js             (fixture file that should be excluded)
```

### Test Results

**Original pattern (with maxdepth 2 and -wholename):**
```
lib/node_modules/@stdlib/mock-package/test/test.js
```

**New pattern (with -path '**/test*/test*.js'):**
```
lib/node_modules/@stdlib/mock-package/test/nested/deeper/test.js
lib/node_modules/@stdlib/mock-package/test/nested/test.js
lib/node_modules/@stdlib/mock-package/test/test.js
```

The output confirms that our changes correctly find all test files in the nested directory structure, while the original pattern only found the top-level test file.

## Testing Instructions

To verify this fix:

1. Clone this repository
2. Check out this branch
3. Run the verification script to see the difference between patterns:

```bash
./final_verification.sh
```

You should see output showing that the new pattern finds all test files, including those in nested directories, while the original pattern only finds top-level test files.

Alternatively, you can test directly with find commands:

```bash
# Original pattern (only finds top-level test files)
find lib/node_modules/@stdlib/mock-package -maxdepth 2 -wholename '**/test/test*.js' | grep -v '/fixtures/'

# New pattern (finds all test files in any nested directory)
find lib/node_modules/@stdlib/mock-package -path '**/test*/test*.js' | grep -v '/fixtures/'
```
