### PR TITLE
Fix test workflow to run tests in nested test directories

### DIFF
--- a/.github/workflows/scripts/run_affected_tests
+++ b/.github/workflows/scripts/run_affected_tests
@@ -151,7 +151,7 @@ main() {
 	done
 
 	# Find all test files in package directories:
-	files=$(find ${directories} -maxdepth 2 -wholename '**/test/test*.js' | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
+	files=$(find ${directories} \( -path "*/test/test*.js" -o -path "*/test/**/test*.js" \) | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
 
 	# Exclude files residing in test fixtures directories:
 	files=$(echo "${files}" | grep -v '/fixtures/') || true

--- a/lib/node_modules/@stdlib/math/base/special/sin/test/nested_dir/test.test.js
+++ b/lib/node_modules/@stdlib/math/base/special/sin/test/nested_dir/test.test.js
@@ -1,0 +1,33 @@
+/**
+* @license Apache-2.0
+*
+* Copyright (c) 2024 The Stdlib Authors.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+'use strict';
+
+// MODULES //
+
+var tape = require( 'tape' );
+var sin = require( './../lib' );
+
+
+// TESTS //
+
+tape( 'main export is a function', function test( t ) {
+	t.ok( true, 'test is executed from a nested directory' );
+	t.equal( typeof sin, 'function', 'main export is a function' );
+	t.end();
+});

--- a/test_find_run.sh
+++ b/test_find_run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Directory to search
+dir="lib/node_modules/@stdlib/math/base/special/sin"
+
+# Use the same pattern as in the script
+files=$(find ${dir} \( -path "*/test/test*.js" -o -path "*/test/**/test*.js" \) | grep -v '/fixtures/' | sort -u | tr '\n' ' ') || true
+
+echo "All found test files:"
+echo "${files}"
+
+if echo "${files}" | grep -q "nested_dir/test.test.js"; then
+    echo "SUCCESS: Nested test file was found!"
+else
+    echo "FAILURE: Nested test file was not found."
+fi


### PR DESCRIPTION
## Problem

The test workflow is not running tests in nested test directories. The current find command in `.github/workflows/scripts/run_affected_tests` uses `-maxdepth 2` which limits the search to only find test files at the top level of the test directory.

## Solution

Modified the find command to search for test files in nested test directories by replacing the `-maxdepth 2 -wholename` pattern with a more inclusive pattern that finds both top-level test files and those in nested directories.

## Testing Instructions

1. Clone the repository
2. Check out this branch
3. Run the included test script to verify the fix works:

```bash
./test_find_run.sh
```

## Test Results

Here is the output from running the test script:

```
All found test files:
lib/node_modules/@stdlib/math/base/special/sin/test/nested_dir/test.test.js lib/node_modules/@stdlib/math/base/special/sin/test/test.js lib/node_modules/@stdlib/math/base/special/sin/test/test.native.js 
SUCCESS: Nested test file was found!
```

This shows that the modified find command correctly identifies test files in both the top-level test directory and in nested subdirectories.